### PR TITLE
Add sample finance rules and test data for stock feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .jbundler
+.vscode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/eventswarm/revs
-  revision: 755ca9bb8fd87f374fc5cd0bb2354684a480e804
+  revision: 2dd0598e6a55dd14ff3f1ff4c031d423377172ea
   specs:
     revs (2.0.0.SNAPSHOT-java)
       activesupport (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/eventswarm/revs
-  revision: 5b1b407404561024028150efe1d29c71b103040a
+  revision: 755ca9bb8fd87f374fc5cd0bb2354684a480e804
   specs:
     revs (2.0.0.SNAPSHOT-java)
       activesupport (~> 4.1)

--- a/app.rb
+++ b/app.rb
@@ -22,8 +22,6 @@ set :bind, '0.0.0.0'
 set :streams, {}
 set :rulesdir, File.join(File.dirname(__FILE__), "rules")
 
-FILTER_PARAMS=['input','output']
-
 class Copier < AbstractProcessor  
   def process(key, value)
     context.forward(key,value)
@@ -58,8 +56,12 @@ def classify_rule(str)
   Object.const_get("Rules::" + str.split('_').map(&:capitalize).join)
 end
 
-def trim_params(params)
-  params.slice(*(params.keys - FILTER_PARAMS))
+def rule_params(params)
+  # remove input/output parameters and rename `rule` to `name`
+  params.slice(*(params.keys - ['input','output'])).tap do |p|
+    p[:name] = p[:rule]
+    p.delete(:rule)
+  end
 end
 
 get '/ping' do
@@ -82,9 +84,10 @@ post '/true' do
   params.merge!(json_params(request)) # accept params either via JSON or URL
 
   
+  safe_params = Hash[rule_params(params)]
   supplier = BlockSupplier.new do
     expr = TrueExpression.new   # use an always true expression
-    rule = Rule.new(expr, expr) # expression is both entry point and match trigger
+    rule = Rule.new(expr, expr, rule_params(safe_params)) # expression is both entry point and match trigger
     RuleProcessor.new(rule)
   end
   json(make_stream(params, supplier, "true")) + "\n"
@@ -92,12 +95,13 @@ end
 
 post '/stream/:rule' do
   content_type :json
-  params.merge!(json_params(request)) # accept params either via JSON or URL
   rule = params[:rule]
+  params.merge!(json_params(request)) # accept params either via JSON or URL
 
   load File.join(settings.rulesdir, "#{rule}.rb")
   klass = classify_rule(rule)
-  supplier = BlockSupplier.new{ RuleProcessor.new(klass.new.create(trim_params(params)), rule) }
+  safe_params = Hash[rule_params(params)]
+  supplier = BlockSupplier.new{ RuleProcessor.new(klass.new.create(safe_params)) }
   json(make_stream(params, supplier, rule)) + "\n"
 end
 

--- a/log4j.properties
+++ b/log4j.properties
@@ -8,4 +8,5 @@ log4j.appender.console.layout.ConversionPattern=%d [%t] %p %c %x - %m%n
 log4j.logger.com.eventswarm=WARN
 
 # Set DEBUG level for a few key classes
-#log4j.logger.com.eventswarm.powerset.HashPowerset=DEBUG
+log4j.logger.com.eventswarm.expressions.ANDExpression=DEBUG
+log4j.logger.com.eventswarm.expressions.SequenceExpression=DEBUG

--- a/rule.rb
+++ b/rule.rb
@@ -21,12 +21,11 @@ class Rule
   #   match_trigger = expression component from which matches should be collected
   #   params = parameters to include in matches for correlation (e.g. rule name, stock symbol)
   #
-  def initialize(add_action, match_trigger, params = {})
-    logger.warn("Creating new rule")
+  def initialize(add_action, match_trigger, params)
     @params = params
     @add_action = add_action
     @match_set = ExpressionMatchSet.new(LastNWindow.new(MAX_MATCHES))
-    match_trigger.java_kind_of?(ComplexExpression) ? 
+    match_trigger.is_a?(ComplexExpression) ? 
       Triggers.complex_match(match_trigger, @match_set) : 
       Triggers.match(match_trigger, @match_set)
   end

--- a/rule.rb
+++ b/rule.rb
@@ -13,15 +13,17 @@ MAX_MATCHES = 100
 class Rule
   include Log4JLogger
   
-  attr_reader :match_set, :add_action
+  attr_reader :match_set, :add_action, :params
 
   #
   # New rule for use by the rule processor
   #   add_action = entry point to the expression
   #   match_trigger = expression component from which matches should be collected
+  #   params = parameters to include in matches for correlation (e.g. rule name, stock symbol)
   #
-  def initialize(add_action, match_trigger)
+  def initialize(add_action, match_trigger, params = {})
     logger.warn("Creating new rule")
+    @params = params
     @add_action = add_action
     @match_set = ExpressionMatchSet.new(LastNWindow.new(MAX_MATCHES))
     match_trigger.java_kind_of?(ComplexExpression) ? 

--- a/rule_processor.rb
+++ b/rule_processor.rb
@@ -63,7 +63,7 @@ class RuleProcessor < AbstractProcessor
   def as_json(event)
     if event.is_a?(Activity)
       # publish an array of the events in the match
-      "[#{event.get_events.map{|event| event.get_json_string}.join(',')}]"
+      "[#{event.get_events.map{|event| as_json(event)}.join(',')}]"
     else
       # publish just the event that matched
       event.get_json_string

--- a/rule_processor.rb
+++ b/rule_processor.rb
@@ -3,6 +3,7 @@ require 'jbundler'
 require 'revs'
 require 'revs/triggers'
 require 'revs/log4_j_logger'
+require 'json'
 
 java_import 'org.apache.kafka.streams.processor.AbstractProcessor'
 java_import 'org.apache.kafka.streams.processor.ProcessorSupplier'
@@ -26,7 +27,6 @@ class RuleProcessor < AbstractProcessor
   def initialize(rule, name = nil)
     super()
     @rule = rule
-    @name = name || @rule.class.name
     Triggers.add(@rule.match_set, self) # catch matches from the rule
   end
 
@@ -51,8 +51,11 @@ class RuleProcessor < AbstractProcessor
     context.forward(forwards_key, match_notification(event))
   end
 
+  #
+  # Since we're using java objects here, I need to encode explicitly 
+  #
   def match_notification(event)
-    "{\"rule\": \"#{@name}\", \"match\": #{as_json(event)}}"
+    "{\"meta\": #{@rule.params.to_json}, \"match\": #{as_json(event)}}"
   end
 
   def as_json(event)

--- a/rule_processor.rb
+++ b/rule_processor.rb
@@ -24,9 +24,10 @@ class RuleProcessor < AbstractProcessor
   include AddEventAction
   include Log4JLogger
 
-  def initialize(rule, name = nil)
+  def initialize(rule)
     super()
     @rule = rule
+    logger.warn("Establishing processor for rule with params #{@rule.params}")
     Triggers.add(@rule.match_set, self) # catch matches from the rule
   end
 
@@ -52,10 +53,11 @@ class RuleProcessor < AbstractProcessor
   end
 
   #
-  # Since we're using java objects here, I need to encode explicitly 
+  # Since we're using java objects here, I can't rely on the json gem and need to encode explicitly 
   #
   def match_notification(event)
-    "{\"meta\": #{@rule.params.to_json}, \"match\": #{as_json(event)}}"
+    logger.warn("Match for rule with params #{@rule.params} and action #{@rule.add_action}")
+    "{\"rule\": #{@rule.params.to_json}, \"match\": #{as_json(event)}}"
   end
 
   def as_json(event)

--- a/rules/a_greaterthan_two.rb
+++ b/rules/a_greaterthan_two.rb
@@ -17,9 +17,9 @@ java_import 'com.eventswarm.expressions.ConstantValue'
 #
 module Rules
   class AGreaterthanTwo
-    def create
+    def create(params = {})
       expr = NumericValueExpression.new(NumericValueExpression::Comparator::GREATER, ConstantValue.new(2), JsonEvent::LongRetriever.new('a'))
-      Rule.new(expr, expr)
+      Rule.new(expr, expr, params)
     end
   end
 end

--- a/rules/a_is_one.rb
+++ b/rules/a_is_one.rb
@@ -18,9 +18,9 @@ java_import 'com.eventswarm.expressions.ConstantValue'
 #
 module Rules
   class AIsOne
-    def create
+    def create(params = {})
       expr = EventMatcherExpression.new(ValueEqualsMatcher.new(ConstantValue.new(1), JsonEvent::LongRetriever.new('a')))
-      Rule.new(expr, expr)
+      Rule.new(expr, expr, params)
     end
   end
 end

--- a/rules/end_of_day.rb
+++ b/rules/end_of_day.rb
@@ -1,0 +1,31 @@
+require 'java'
+require 'rule'
+require 'revs'
+require 'revs/log4_j_logger'
+require 'revs/triggers'
+
+java_import 'com.eventswarm.events.JsonEvent'
+java_import 'com.eventswarm.expressions.StringValueMatcher'
+java_import 'com.eventswarm.expressions.EventMatcherExpression'
+
+#
+# Rule creator that looks for repeated price changes in a stream of stock quote events followed by end-of-day
+#
+# Four parameters are accepted:
+#   symbol: stock symbol (default = 'MSFT')
+#   length: number of consecutive events to match (default = 5)
+#   path: path to json attribute (default = 'open')
+#   direction: direction of change (up=1, flat=0, down=-1), (default=1)
+#
+module Rules
+  class EndOfDay
+    include Log4JLogger
+    
+    INCREASE=1
+
+    def create(params = {})
+      end_of_day = EventMatcherExpression.new(StringValueMatcher.new("End Of Day", JsonEvent::StringRetriever.new('event')))
+      Rule.new(end_of_day, end_of_day, params)
+    end
+  end
+end

--- a/rules/end_of_day_price_change.rb
+++ b/rules/end_of_day_price_change.rb
@@ -1,0 +1,44 @@
+require 'java'
+require 'rule'
+require 'revs'
+require 'revs/log4_j_logger'
+require 'revs/triggers'
+
+java_import 'com.eventswarm.events.JsonEvent'
+java_import 'com.eventswarm.expressions.ValueGradientExpression'
+java_import 'com.eventswarm.expressions.StringValueMatcher'
+java_import 'com.eventswarm.eventset.EventMatchPassThruFilter'
+java_import 'com.eventswarm.expressions.SequenceExpression'
+java_import 'com.eventswarm.expressions.EventMatcherExpression'
+java_import 'java.util.ArrayList'
+
+#
+# Rule creator that looks for repeated price changes in a stream of stock quote events followed by end-of-day
+#
+# Four parameters are accepted:
+#   symbol: stock symbol (default = 'MSFT')
+#   length: number of consecutive events to match (default = 5)
+#   path: path to json attribute (default = 'open')
+#   direction: direction of change (up=1, flat=0, down=-1), (default=1)
+#
+module Rules
+  class EndOfDayPriceChange
+    include Log4JLogger
+    
+    INCREASE=1
+
+    def create(params = {})
+      length = Integer(params["length"]) || 5
+      path = params["path"] || 'open'
+      symbol = params["symbol"] || 'MSFT'
+      direction = Integer(params["direction"]) || INCREASE
+      logger.warn("new EndOfDayPriceChange with length: #{length}, path: #{path}, symbol: #{symbol} and direction: #{direction}")
+      filter = EventMatchPassThruFilter.new(StringValueMatcher.new(symbol, JsonEvent::StringRetriever.new('symbol')))
+      gradient = ValueGradientExpression.new(length, JsonEvent::DoubleRetriever.new(path), direction)
+      end_of_day = EventMatcherExpression.new(StringValueMatcher.new("End Of Day", JsonEvent::StringRetriever.new('event')))
+      sequence = SequenceExpression.new(ArrayList.new([gradient, end_of_day]))
+      Triggers.add(filter,sequence)
+      Rule.new(filter, sequence, params)
+    end
+  end
+end

--- a/rules/price_change.rb
+++ b/rules/price_change.rb
@@ -1,0 +1,39 @@
+require 'java'
+require 'rule'
+require 'revs'
+require 'revs/triggers'
+require 'revs/log4_j_logger'
+
+java_import 'com.eventswarm.events.JsonEvent'
+java_import 'com.eventswarm.expressions.ValueGradientExpression'
+java_import 'com.eventswarm.expressions.StringValueMatcher'
+java_import 'com.eventswarm.eventset.EventMatchPassThruFilter'
+
+#
+# Rule creator that looks for repeated price changes in a stream of stock quote events
+#
+# Four parameters are accepted:
+#   symbol: stock symbol (default = 'MSFT')
+#   length: number of consecutive events to match (default = 5)
+#   path: path to json attribute (default = 'open')
+#   direction: direction of change (up=1, flat=0, down=-1), (default=1)
+#
+module Rules
+  class PriceChange
+    include Log4JLogger
+
+    INCREASE=1
+
+    def create(params = {})
+      length = Integer(params["length"]) || 5
+      path = params["path"] || 'open'
+      symbol = params["symbol"] || 'MSFT'
+      direction = Integer(params["direction"]) || INCREASE
+      logger.warn("new PriceChange with length: #{length}, path: #{path}, symbol: #{symbol} and direction: #{direction}")
+      filter = EventMatchPassThruFilter.new(StringValueMatcher.new(symbol, JsonEvent::StringRetriever.new('symbol')))
+      expr = ValueGradientExpression.new(length, JsonEvent::DoubleRetriever.new(path), direction)
+      Triggers.add(filter, expr)
+      Rule.new(filter, expr, params)
+    end
+  end
+end

--- a/rules/two_true.rb
+++ b/rules/two_true.rb
@@ -14,9 +14,9 @@ java_import 'com.eventswarm.expressions.SequenceExpression'
 #
 module Rules
   class TwoTrue
-    def create
+    def create(params = {})
       expr = SequenceExpression.new([TrueExpression.new,TrueExpression.new])
-      Rule.new(expr, expr)
+      Rule.new(expr, expr, params)
     end
   end
 end

--- a/test/fixtures/MSFT/MSFT_1584733800000.json
+++ b/test/fixtures/MSFT/MSFT_1584733800000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584733800000,
+    "open": 137.7,
+    "high": 137.73,
+    "low": 135.86,
+    "close": 136.59,
+    "volume": 0,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584733800000.json
+++ b/test/fixtures/MSFT/MSFT_1584733800000.json
@@ -1,5 +1,6 @@
 {
     "timestamp": 1584733800000,
+    "event": "quote",
     "open": 137.7,
     "high": 137.73,
     "low": 135.86,

--- a/test/fixtures/MSFT/MSFT_1584733860000.json
+++ b/test/fixtures/MSFT/MSFT_1584733860000.json
@@ -1,5 +1,6 @@
 {
     "timestamp": 1584733860000,
+    "event": "quote",
     "open": 136.6,
     "high": 137.95,
     "low": 136.47,

--- a/test/fixtures/MSFT/MSFT_1584733860000.json
+++ b/test/fixtures/MSFT/MSFT_1584733860000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584733860000,
+    "open": 136.6,
+    "high": 137.95,
+    "low": 136.47,
+    "close": 137.3,
+    "volume": 411258,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584733920000.json
+++ b/test/fixtures/MSFT/MSFT_1584733920000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584733920000,
+    "open": 137.31,
+    "high": 137.68,
+    "low": 137.0,
+    "close": 137.31,
+    "volume": 325404,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584733920000.json
+++ b/test/fixtures/MSFT/MSFT_1584733920000.json
@@ -1,5 +1,6 @@
 {
     "timestamp": 1584733920000,
+    "event": "quote",
     "open": 137.31,
     "high": 137.68,
     "low": 137.0,

--- a/test/fixtures/MSFT/MSFT_1584733980000.json
+++ b/test/fixtures/MSFT/MSFT_1584733980000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584733980000,
+        "open": 137.01,
+        "high": 137.24,
+        "low": 136.5,
+        "close": 136.56,
+        "volume": 390107,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584733980000.json
+++ b/test/fixtures/MSFT/MSFT_1584733980000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584733980000,
-        "open": 137.01,
-        "high": 137.24,
-        "low": 136.5,
-        "close": 136.56,
-        "volume": 390107,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 137.01,
+    "high": 137.24,
+    "low": 136.5,
+    "close": 136.56,
+    "volume": 390107,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734040000.json
+++ b/test/fixtures/MSFT/MSFT_1584734040000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734040000,
+        "open": 136.55,
+        "high": 138.71,
+        "low": 136.48,
+        "close": 138.27,
+        "volume": 649071,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584734040000.json
+++ b/test/fixtures/MSFT/MSFT_1584734040000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734040000,
-        "open": 136.55,
-        "high": 138.71,
-        "low": 136.48,
-        "close": 138.27,
-        "volume": 649071,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 136.55,
+    "high": 138.71,
+    "low": 136.48,
+    "close": 138.27,
+    "volume": 649071,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734100000.json
+++ b/test/fixtures/MSFT/MSFT_1584734100000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734100000,
-        "open": 138.26,
-        "high": 138.26,
-        "low": 137.51,
-        "close": 137.54,
-        "volume": 465480,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 138.26,
+    "high": 138.26,
+    "low": 137.51,
+    "close": 137.54,
+    "volume": 465480,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734100000.json
+++ b/test/fixtures/MSFT/MSFT_1584734100000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734100000,
+        "open": 138.26,
+        "high": 138.26,
+        "low": 137.51,
+        "close": 137.54,
+        "volume": 465480,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584734160000.json
+++ b/test/fixtures/MSFT/MSFT_1584734160000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734160000,
+        "open": 137.5,
+        "high": 138.4,
+        "low": 137.4,
+        "close": 137.57,
+        "volume": 542332,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584734160000.json
+++ b/test/fixtures/MSFT/MSFT_1584734160000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734160000,
-        "open": 137.5,
-        "high": 138.4,
-        "low": 137.4,
-        "close": 137.57,
-        "volume": 542332,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 137.5,
+    "high": 138.4,
+    "low": 137.4,
+    "close": 137.57,
+    "volume": 542332,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734220000.json
+++ b/test/fixtures/MSFT/MSFT_1584734220000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734220000,
+        "open": 137.54,
+        "high": 138.1,
+        "low": 136.8,
+        "close": 136.82,
+        "volume": 710896,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584734220000.json
+++ b/test/fixtures/MSFT/MSFT_1584734220000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734220000,
-        "open": 137.54,
-        "high": 138.1,
-        "low": 136.8,
-        "close": 136.82,
-        "volume": 710896,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 137.54,
+    "high": 138.1,
+    "low": 136.8,
+    "close": 136.82,
+    "volume": 710896,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734280000.json
+++ b/test/fixtures/MSFT/MSFT_1584734280000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734280000,
-        "open": 136.82,
-        "high": 137.79,
-        "low": 136.81,
-        "close": 137.2,
-        "volume": 841574,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 136.82,
+    "high": 137.79,
+    "low": 136.81,
+    "close": 137.2,
+    "volume": 841574,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734280000.json
+++ b/test/fixtures/MSFT/MSFT_1584734280000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734280000,
+        "open": 136.82,
+        "high": 137.79,
+        "low": 136.81,
+        "close": 137.2,
+        "volume": 841574,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_1584734340000.json
+++ b/test/fixtures/MSFT/MSFT_1584734340000.json
@@ -1,11 +1,12 @@
 {
     "timestamp": 1584734340000,
-        "open": 137.2,
-        "high": 137.7,
-        "low": 136.56,
-        "close": 136.77,
-        "volume": 1430893,
-        "dividends": 0,
-        "stock splits": 0,
-        "symbol": "MSFT"
+    "event": "quote",
+    "open": 137.2,
+    "high": 137.7,
+    "low": 136.56,
+    "close": 136.77,
+    "volume": 1430893,
+    "dividends": 0,
+    "stock splits": 0,
+    "symbol": "MSFT"
 }

--- a/test/fixtures/MSFT/MSFT_1584734340000.json
+++ b/test/fixtures/MSFT/MSFT_1584734340000.json
@@ -1,0 +1,11 @@
+{
+    "timestamp": 1584734340000,
+        "open": 137.2,
+        "high": 137.7,
+        "low": 136.56,
+        "close": 136.77,
+        "volume": 1430893,
+        "dividends": 0,
+        "stock splits": 0,
+        "symbol": "MSFT"
+}

--- a/test/fixtures/MSFT/MSFT_end.json
+++ b/test/fixtures/MSFT/MSFT_end.json
@@ -1,0 +1,4 @@
+{
+    "timestamp": 1584734400000,
+        "Event": "End Of Day"
+}

--- a/test/fixtures/MSFT/MSFT_end.json
+++ b/test/fixtures/MSFT/MSFT_end.json
@@ -1,4 +1,5 @@
 {
+    "symbol": "MSFT",
     "timestamp": 1584734400000,
     "event": "End Of Day"
 }

--- a/test/fixtures/MSFT/MSFT_end.json
+++ b/test/fixtures/MSFT/MSFT_end.json
@@ -1,4 +1,4 @@
 {
     "timestamp": 1584734400000,
-        "Event": "End Of Day"
+    "event": "End Of Day"
 }

--- a/test/fixtures/MSFT/MSFT_start.json
+++ b/test/fixtures/MSFT/MSFT_start.json
@@ -1,0 +1,4 @@
+{
+    "timestamp": 1584711000000,
+        "Event": "Start Of Day"
+}

--- a/test/fixtures/MSFT/MSFT_start.json
+++ b/test/fixtures/MSFT/MSFT_start.json
@@ -1,4 +1,5 @@
 {
+    "symbol": "MSFT",
     "timestamp": 1584711000000,
     "event": "Start Of Day"
 }

--- a/test/fixtures/MSFT/MSFT_start.json
+++ b/test/fixtures/MSFT/MSFT_start.json
@@ -1,4 +1,4 @@
 {
     "timestamp": 1584711000000,
-        "Event": "Start Of Day"
+    "event": "Start Of Day"
 }


### PR DESCRIPTION
Three new rules, namely:
- end_of_day
- price_change
- end_of_day_price_change

A few changes to support these, including:
- sample data based on discussion with @luong
- support for passing parameters to rules
- updated revs gem to get ValueGradientExpression and a number of related bug fixes
- more debug output